### PR TITLE
1-line bugfix for newer versions of "tm" package > v0.60

### DIFF
--- a/082-word-cloud/global.R
+++ b/082-word-cloud/global.R
@@ -18,11 +18,11 @@ getTermMatrix <- memoise(function(book) {
     encoding="UTF-8")
 
   myCorpus = Corpus(VectorSource(text))
-  myCorpus = tm_map(myCorpus, tolower)
+  myCorpus = tm_map(myCorpus, content_transformer(tolower))
   myCorpus = tm_map(myCorpus, removePunctuation)
   myCorpus = tm_map(myCorpus, removeNumbers)
   myCorpus = tm_map(myCorpus, removeWords,
-    c(stopwords("SMART"), "thy", "thou", "thee"))
+         c(stopwords("SMART"), "thy", "thou", "thee", "the", "and", "but"))
 
   myDTM = TermDocumentMatrix(myCorpus,
               control = list(minWordLength = 1))


### PR DESCRIPTION
Avoid Error message  

```
" Warning in mclapply(unname(content(x)), termFreq, control) :
  all scheduled cores encountered errors in user code
Error in UseMethod("meta", x) :
  no applicable method for 'meta' applied to an object of class "character"
 "
```

The latest version of tm (0.60) made it so you can't use functions with tm_map that operate on simple character values any more. So the problem is your tolower() step since that isn't an "canonical" transformation (See getTransformations()).
see: http://stackoverflow.com/a/24771621/202553
