### PR TITLE
Move palette customization into renderPlot

### DIFF
--- a/050-kmeans-example/server.R
+++ b/050-kmeans-example/server.R
@@ -1,6 +1,3 @@
-palette(c("#E41A1C", "#377EB8", "#4DAF4A", "#984EA3",
-  "#FF7F00", "#FFFF33", "#A65628", "#F781BF", "#999999"))
-
 function(input, output, session) {
 
   # Combine the selected variables into a new data frame
@@ -13,6 +10,9 @@ function(input, output, session) {
   })
 
   output$plot1 <- renderPlot({
+    palette(c("#E41A1C", "#377EB8", "#4DAF4A", "#984EA3",
+      "#FF7F00", "#FFFF33", "#A65628", "#F781BF", "#999999"))
+
     par(mar = c(5.1, 4.1, 0, 1))
     plot(selectedData(),
          col = clusters()$cluster,


### PR DESCRIPTION
Calling palette() at the top level (with no graphics device) causes
an Rplots.pdf file to be temporarily created in the app dir.