### PR TITLE
Add namespaced conditional panel demo

### DIFF
--- a/119-namespaced-conditionalpanel-demo/DESCRIPTION
+++ b/119-namespaced-conditionalpanel-demo/DESCRIPTION
@@ -1,0 +1,7 @@
+Type: Shiny
+Title: Namespaced conditionalPanel demo
+License: MIT
+Author: Alan Dipert <alan@rstudio.com>
+AuthorUrl: http://www.rstudio.com/
+Tags: conditionalpanel
+DisplayMode: Showcase

--- a/119-namespaced-conditionalpanel-demo/app.R
+++ b/119-namespaced-conditionalpanel-demo/app.R
@@ -1,0 +1,54 @@
+myPlotUI <- function(id, label = "My Plot") {
+  ns <- NS(id)
+  tagList(
+    column(4, wellPanel(
+      sliderInput(
+        ns("n"),
+        "Number of points:",
+        min = 10,
+        max = 200,
+        value = 50,
+        step = 10
+      )
+    )),
+
+    column(
+      5,
+      tags$h2(label),
+      "The plot below will be not displayed when the slider value",
+      "is less than 50.",
+
+      # With the conditionalPanel, the condition is a JavaScript
+      # expression. In these expressions, input values like
+      # input$n are accessed with dots, as in input.n
+      conditionalPanel("input.n >= 50",
+                       ## The condition is namespaced to this particular
+                       ## instance of this module by providing the ns parameter.
+                       ## Consequently, input.n refers to this module's input
+                       ## named n, and no other.
+                       ns = ns,
+                       plotOutput(ns("scatterPlot"), height = 300))
+    )
+  )
+}
+
+myPlot <- function(input, output, session, deviates) {
+  output$scatterPlot <- renderPlot({
+    x <- rnorm(input$n)
+    y <- rnorm(input$n)
+    plot(x, y)
+  })
+}
+
+server <- function(input, output) {
+  callModule(myPlot, "plot1")
+  callModule(myPlot, "plot2")
+}
+
+ui <- fluidPage(
+  titlePanel("Namespaced conditional panels"),
+  myPlotUI("plot1", label = "My first plot"),
+  myPlotUI("plot2", label = "My second plot")
+)
+
+shinyApp(ui = ui, server = server)


### PR DESCRIPTION
This demo packages the other conditional panel demo into a module, and demonstrates the use of the `ns` argument to `conditionalPanel` as introduced by https://github.com/rstudio/shiny/pull/1735