### PR TITLE
Fix for `122-async-outputs` image download problem

### DIFF
--- a/122-async-outputs/app.R
+++ b/122-async-outputs/app.R
@@ -88,14 +88,14 @@ server <- function(input, output, session) {
 
   output$image <- renderImage({
     path <- tempfile(fileext = ".gif")
-    download.file("https://www.google.com/images/logo.gif", path)
+    download.file("https://www.google.com/images/logo.gif", path, mode = "wb")
     list(src = path)
   }, deleteFile = TRUE)
 
   output$imagea <- renderImage({
     future({
       path <- tempfile(fileext = ".gif")
-      download.file("https://www.google.com/images/logo.gif", path)
+      download.file("https://www.google.com/images/logo.gif", path, mode = "wb")
       path
     }) %...>% {
       list(src = .)


### PR DESCRIPTION
Images are corrupted upon download. This adds `mode = "wb"` to the `download.file()` statements inside each `renderImage()`.