### PR TITLE
Remove s from `https` for google logo image

### DIFF
--- a/122-async-outputs/app.R
+++ b/122-async-outputs/app.R
@@ -88,14 +88,14 @@ server <- function(input, output, session) {
 
   output$image <- renderImage({
     path <- tempfile(fileext = ".gif")
-    download.file("https://www.google.com/images/logo.gif", path, mode = "wb")
+    download.file("http://www.google.com/images/logo.gif", path, mode = "wb")
     list(src = path)
   }, deleteFile = TRUE)
 
   output$imagea <- renderImage({
     future({
       path <- tempfile(fileext = ".gif")
-      download.file("https://www.google.com/images/logo.gif", path, mode = "wb")
+      download.file("http://www.google.com/images/logo.gif", path, mode = "wb")
       path
     }) %...>% {
       list(src = .)


### PR DESCRIPTION
RSP has issues with downloading two HTTPS images from the same url one after another.  However, this app doesn't need https to prove it is working, so they are removed and the RSP issue goes away.

For RSP, could instead use `method = "wget"`, as `"libcurl"` or `"curl"` do not work.

Error received if the download.file is upgraded to a httr command

> Error in curl::curl_fetch_disk: A PKCS # 11 module returned CKR_DEVICE_ERROR, indicating that a problem has occurred with the token or slot.
