### PR TITLE
don't use knitr evaluate hook workaround unless it makes sense to

### DIFF
--- a/020-knit-html/server.R
+++ b/020-knit-html/server.R
@@ -1,7 +1,13 @@
 # Workaround for https://github.com/yihui/knitr/issues/1538
-evaluate2 <- function(...) evaluate::evaluate(...)
-environment(evaluate2) <- asNamespace("knitr")
-knitr::knit_hooks$set(evaluate = evaluate2)
+if (packageVersion("knitr") < "1.17.3") {
+  if (getRversion() > "3.4.0") {
+    evaluate2 <- function(...) evaluate::evaluate(...)
+    environment(evaluate2) <- asNamespace("knitr")
+    knitr::knit_hooks$set(evaluate = evaluate2)
+  } else {
+    stop("Update knitr to run this app", call. = FALSE)
+  }
+}
 
 function(input, output) {
 


### PR DESCRIPTION
On older versions of R, setting the evaluate hook in this way can mess up knitr's other hooks, but setting the hook isn't necessary with a modern version of knitr

See https://github.com/yihui/knitr/issues/1538 for more context