### PR TITLE
Consolidate package installation scripts

### DIFF
--- a/docker-rsc-deployer/Dockerfile
+++ b/docker-rsc-deployer/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN bash -c 'echo "will cite" | parallel --bibtex'
 
-RUN R -e "install.packages('packrat')"
+RUN R -e "install.packages(c('devtools', 'packrat'))"
 
 # Install shiny-examples, and fix permissions for apps that require write
 # access to /shiny-examples

--- a/docker-rsc-deployer/Dockerfile
+++ b/docker-rsc-deployer/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN bash -c 'echo "will cite" | parallel --bibtex'
 
-RUN R -e "install.packages(c('devtools', 'packrat', 'knitr'))"
+RUN R -e "install.packages('packrat')"
 
 # Install shiny-examples, and fix permissions for apps that require write
 # access to /shiny-examples
@@ -104,23 +104,8 @@ RUN cd / && \
     cd shiny-examples
 
 
-# Autodetect packages needed for the examples (will install from CRAN)
-RUN R -e "install.packages(setdiff(packrat:::dirDependencies('/srv/shiny-server'), rownames(installed.packages())))"
-
 # Packages that need to be installed from GitHub
-# For 087-crandash
-RUN R -e "devtools::install_github('hadley/shinySignals')"
-RUN R -e "devtools::install_github('jcheng5/bubbles')"
-
-# For deploying apps to RSC
-RUN R -e "devtools::install_github('rstudio/rsconnect')"
-
-# RC Branches
-RUN R -e 'devtools::install_github("rstudio/websocket")'
-RUN R -e 'devtools::install_github("rstudio/DT")'
-RUN R -e 'devtools::install_github("r-lib/scales")'
-RUN R -e 'devtools::install_github("rstudio/httpuv@rc-v1.5.1")'
-RUN R -e 'devtools::install_github("rstudio/shiny@rc-v1.3.0")'
+RUN R -e 'source("/install_deps.R", echo = TRUE)'
 
 
 COPY deployApp.R /usr/local/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,7 +106,7 @@ CMD ["/usr/bin/shiny-server.sh"]
 RUN apt-get update && apt-get install -y \
     libxml2-dev
 
-RUN R -e "install.packages('packrat')"
+RUN R -e "install.packages(c('devtools', 'packrat'))"
 
 # For deploying apps from a container
 RUN R -e "devtools::install_github('rstudio/rsconnect')"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,7 +106,7 @@ CMD ["/usr/bin/shiny-server.sh"]
 RUN apt-get update && apt-get install -y \
     libxml2-dev
 
-RUN R -e "install.packages(c('devtools', 'packrat'))"
+RUN R -e "install.packages('packrat')"
 
 # For deploying apps from a container
 RUN R -e "devtools::install_github('rstudio/rsconnect')"
@@ -122,20 +122,5 @@ RUN cd /srv && \
     cd shiny-server && \
     chmod 777 022-unicode-chinese 055-observer-demo 059-reactive-poll-and-file-reader
 
-# Autodetect packages needed for the examples (will install from CRAN)
-RUN R -e "install.packages(setdiff(packrat:::dirDependencies('/srv/shiny-server'), rownames(installed.packages())))"
-
 # Packages that need to be installed from GitHub
-# For 087-crandash
-RUN R -e "devtools::install_github('hadley/shinySignals')"
-RUN R -e "devtools::install_github('jcheng5/bubbles')"
-# For 150-reactr-input
-RUN R -e 'devtools::install_github("react-R/reactR")'
-
-# RC Branches
-RUN R -e 'devtools::install_github("rstudio/websocket")'
-RUN R -e 'devtools::install_github("ramnathv/htmlwidgets")'
-RUN R -e 'devtools::install_github("rstudio/DT")'
-RUN R -e 'devtools::install_github("r-lib/scales")'
-RUN R -e 'devtools::install_github("rstudio/httpuv")'
-RUN R -e 'devtools::install_github("rstudio/shiny@rc-v1.3.1")'
+RUN R -e 'source("/srv/shiny-server/install_deps.R", echo = TRUE)'

--- a/install_deps.R
+++ b/install_deps.R
@@ -1,0 +1,67 @@
+#!/usr/bin/env Rscript
+
+# This script installs some development packages that are needed for various
+# apps. It can be sourced from RStudio, or run with Rscript.
+
+
+# Returns the file currently being sourced or run with Rscript
+this_file <- function() {
+  cmdArgs <- commandArgs(trailingOnly = FALSE)
+  needle <- "--file="
+  match <- grep(needle, cmdArgs)
+  if (length(match) > 0) {
+    # Rscript
+    return(normalizePath(sub(needle, "", cmdArgs[match])))
+  } else {
+    # 'source'd via R console
+    return(normalizePath(sys.frames()[[1]]$ofile))
+  }
+}
+
+is_installed <- function (pkg) {
+  if (system.file(package = pkg) == "")
+    FALSE
+  else
+    TRUE
+}
+
+# Install a package or packages if not already installed.
+install_if_needed <- function(pkgs) {
+  installed_idx <- vapply(pkgs, is_installed, TRUE)
+  needed <- pkgs[!installed_idx]
+  if (length(needed) > 0) {
+    message("Installing needed packages from CRAN: ", paste(needed, collapse = ", "))
+    install.packages(needed)
+  }
+}
+
+# Core packages
+install_if_needed(c("devtools", "rsconnect", "packrat", "knitr"))
+
+# Autodetect packages needed for the examples (will install from CRAN)
+install_if_needed(packrat:::dirDependencies(dirname(this_file())))
+
+# Some packages must be installed from GitHub
+devtools::install_github(c(
+  # For 087-crandash
+  "hadley/shinySignals",
+  "jcheng5/bubbles",
+
+  # For 144-colors
+  "r-lib/scales",
+
+  # For 145-dt-replacedata
+  "rstudio/DT",
+
+  # For 147-websocket
+  "rstudio/websocket",
+
+  # For 149-onRender
+  "ramnathv/htmlwidgets",
+
+  # For 150-reactr-input
+  "react-R/reactR",
+
+  "rstudio/httpuv",
+  "rstudio/shiny@rc-v1.3.1"
+))

--- a/linux-devel-init.sh
+++ b/linux-devel-init.sh
@@ -52,27 +52,14 @@ cd /tmp \
  && git clone --depth 1 https://github.com/wch/r-debug.git \
  && ./r-debug/r-devel/buildR.sh
 
-# Install helper packages
-RD -q -e 'install.packages(c("devtools", "packrat", "knitr"))'
+# Install packrat to detect other dependencies
+RD -q -e 'install.packages("packrat")'
 
 # download examples to home folder and install dependencies
 cd ~ \
  && git clone --depth 1 https://github.com/rstudio/shiny-examples.git \
  && RD -q -e 'install.packages(packrat:::dirDependencies("shiny-examples"))'
 
-# install github pkgs
-RD -q -e 'install.packages(c("ggvis", "dbplyr", "tm", "highcharter", "readr", "radiant"))'
-RD -q -e 'devtools::install_github("jcheng5/bubbles")'
-RD -q -e 'devtools::install_github("hadley/shinySignals")'
-# For 150-reactr-input
-RD -q -e 'devtools::install_github("react-R/reactR")'
-
-# RC Branches
-RD -q -e 'devtools::install_github("rstudio/websocket")'
-RD -q -e 'devtools::install_github("ramnathv/htmlwidgets")'
-RD -q -e 'devtools::install_github("rstudio/DT")'
-RD -q -e 'devtools::install_github("r-lib/scales")'
-RD -q -e 'devtools::install_github("rstudio/httpuv")'
-RD -q -e 'devtools::install_github("rstudio/shiny@rc-v1.3.1")'
+Rscript -e 'source("shiny-examples/install_deps.R", echo = TRUE)'
 
 # cd ~/shiny-examples && RSTUDIO_WHICH_R=`which RD` rstudio

--- a/run_apps.R
+++ b/run_apps.R
@@ -161,37 +161,5 @@ url_links <- function(base_url) {
   invisible(links)
 }
 
-
-
-
-
-# make sure all packages are installed
-maybe_install_pkg <- function(pkg) {
-  tryCatch({
-    packageVersion(pkg)
-  }, error = function(e) {
-    install.packages(pkg)
-  })
-}
-# core packages
-lapply(
-  c("devtools", "rsconnect", "packrat"),
-  maybe_install_pkg
-)
-
-# extra pkgs
-devtools::install_github("hadley/shinySignals")
-devtools::install_github("jcheng5/bubbles")
-devtools::install_github("react-R/reactR")
-
-# RC Branches # should not reinstall if the SHA is the same
-devtools::install_github("rstudio/websocket")
-devtools::install_github("ramnathv/htmlwidgets")
-devtools::install_github("rstudio/DT")
-devtools::install_github("r-lib/scales")
-devtools::install_github("ramnathv/htmlwidgets")
-devtools::install_github("rstudio/httpuv")
-devtools::install_github("rstudio/shiny@rc-v1.3.1")
-
-# install all packages
-lapply(packrat:::dirDependencies("."), maybe_install_pkg)
+# Install packages needed for examples
+source("install_deps.R", echo = TRUE)


### PR DESCRIPTION
This has a similar goal to #134. One advantage of this approach is that it documents which app needs which package. However, it also has the problem that a change in the packages listed in `install_deps.R` will not bust the cache for the Docker build.