### PR TITLE
Add instructions to 107-events and add test for new event behavior

### DIFF
--- a/107-events/server.R
+++ b/107-events/server.R
@@ -42,6 +42,10 @@ function(input, output, session) {
     Sys.sleep(2)
   })
 
+  observeEvent(input$swallow_event_button, {
+    session$sendCustomMessage('swallow_fail', list(msg = "Fail"))
+  })
+
   observeEvent(input$end, session$close())
 
 }

--- a/107-events/ui.R
+++ b/107-events/ui.R
@@ -1,4 +1,30 @@
 library(shiny)
+library(knitr)
+
+md <- '
+# JavaScript event tests
+
+This app exercises Shiny\'s [JavaScript events API](https://shiny.rstudio.com/articles/js-events.html).
+
+1. A dialog box that says "Shiny is busy!" should appear at least twice in succession immediately after page load.
+1. The side panel should fade during or after the "Shiny is busy!" dialog box has subsided.
+1. The slider input labeled **Number of bins** should have a red dotted border.
+1. Modifying the "Title" text input should cause the plot title to update.
+1. Pressing the button labeled "Change color" should cause the bars in the plot to change color.
+1. Pressing the button labeled "Change color (canceled)" should have no effect.
+1. Pressing the button labeled "Send message" should cause the busy dialog to appear very briefly.
+1. Pressing the button labeled "Be busy for 2 seconds" should cause the busy dialog to appear for roughly 2 seconds.
+1. Pressing the "Swallow event" button should **not** cause an alert box that says "Fail" to appear.
+1. The JavaScript console should display the following kinds of messages (input/output names elided):
+  - `An output ... was bound to Shiny`
+  - `An input ... was bound to Shiny`
+  - `Received a message from Shiny`
+  - `An output is being recalculated...`
+1. `My output was modified by the shiny:value event.` should appear under the **slider_info2** heading.
+1. `Error: A nice error occurred :)` should appear under the **Error Info** heading.
+1. `Warning: Error in renderPrint: A bad error occurred!` should appear in the R console at least twice.
+1. Pressing the button labeled "End session" should cause an alert to say "Disconnected!"
+'
 
 fluidPage(
 
@@ -14,13 +40,20 @@ fluidPage(
       actionButton('color2', 'Change color (canceled)'),
       actionButton('message', 'Send message'),
       actionButton('busy', 'Be busy for 2 seconds'),
+      tags$span(
+        id = "swallow_wrapper",
+        actionButton('swallow_event_button', 'Swallow event')
+      ),
       actionButton('end', 'End session')
     ),
 
     mainPanel(
+      HTML(knit2html(fragment.only = TRUE, text = md)),
       plotOutput('distPlot'),
       verbatimTextOutput('slider_info1'),
+      tags$h3("slider_info2"),
       verbatimTextOutput('slider_info2'),
+      tags$h3("Error Info"),
       textOutput('error_info')
     )
   ),

--- a/107-events/www/events.js
+++ b/107-events/www/events.js
@@ -1,4 +1,7 @@
 $(function() {
+  $("#swallow_wrapper").on('shiny:inputchanged', function(event) {
+    event.preventDefault();
+  });
   $(document).on({
 
     'shiny:connected': function(event) {
@@ -41,6 +44,8 @@ $(function() {
       if (msg.hasOwnProperty('custom') && msg.custom.hasOwnProperty('special')) {
         console.log('This is a special message from Shiny:');
         console.log(msg.custom.special);
+      } else if (msg.hasOwnProperty('custom') && msg.custom.hasOwnProperty('swallow_fail')) {
+        alert(msg.custom.swallow_fail.msg);
       }
     },
 
@@ -57,8 +62,7 @@ $(function() {
 
     'shiny:value': function(event) {
       if (event.name === 'slider_info2') {
-        event.value = 'My output was modified by the shiny:value event.\n' +
-                      'Now I do not know the value of the slider.';
+        event.value = 'My output was modified by the shiny:value event.';
       }
     },
 


### PR DESCRIPTION
`107-events` is a decent exercise of Shiny's [JavaScript events API](https://shiny.rstudio.com/articles/js-events.html) but it didn't have any instructions.

I added testing instructions, and also a new test for new behavior introduced to Shiny via rstudio/shiny#2446

Consequently, `107-events` now **fails** on Shiny version <= 1.3.2 and passes with Shiny from master.