### PR TITLE
Fix for 157-date-format: ensure inputs are rendered after test results

### DIFF
--- a/157-date-format/app.R
+++ b/157-date-format/app.R
@@ -33,6 +33,16 @@ server <- function(input, output, session) {
     })
   }
 
+  output$warnings <- renderPrint(warn_messages())
+
+  output$res <- renderUI({
+    n <- length(warn_messages())
+    status <- if (n == 14)
+      tags$b("Test passed, move along!", style = "color: green")
+    else
+      p(tags$b("Fail:", style = "color: red"), "expected 14 warnings, but got", n)
+  })
+
   output$inputs <- renderUI({
     tagList(
       catchWarning(dateInput, "x1", "Mis-specified `value`", value = "2014-13-1"),
@@ -55,16 +65,6 @@ server <- function(input, output, session) {
     catchWarning(updateDateRangeInput, session, "x5", start = "29", return = FALSE)
     catchWarning(updateDateRangeInput, session, "x6", max = "val", return = FALSE)
     catchWarning(updateDateRangeInput, session, "x7", min = "$", return = FALSE)
-  })
-
-  output$warnings <- renderPrint(warn_messages())
-
-  output$res <- renderUI({
-    n <- length(warn_messages())
-    status <- if (n == 14)
-      tags$b("Test passed, move along!", style = "color: green")
-    else
-      p(tags$b("Fail:", style = "color: red"), "expected 14 warnings, but got", n)
   })
 
 }


### PR DESCRIPTION
Rendering `output$inputs` in this app has always produced JS errors (see https://github.com/rstudio/shiny/issues/2591 for minimal example), but that wasn't a noticeable issue until https://github.com/rstudio/shiny/pull/2429, which changed the order in which the outputs execute. Specifically, prior to https://github.com/rstudio/shiny/pull/2429, the test results (i.e. `output$res`) were rendered before `output$input`. After https://github.com/rstudio/shiny/pull/2429,  `output$input` now renders first, and as a result, the JS errors it produces prevents the test results from rendering.

This change ensures the test results are rendered first, but after https://github.com/rstudio/shiny/issues/2591 is fixed, the ordering won't matter.