### PR TITLE
121-async-timer: Use stderr instead of stdout to print message

### DIFF
--- a/121-async-timer/app.R
+++ b/121-async-timer/app.R
@@ -24,7 +24,7 @@ server <- function(input, output, session) {
   })
 
   session$onFlushed(function() {
-    print("Flushed")
+    message("Flushed")
   }, once = FALSE)
 
   output$out <- renderText({


### PR DESCRIPTION
cc @MadhulikaTanuboddi 

Makes it possible to verify 121-async-timer is printing messages, when running under Connect or SSP.