### PR TITLE
make sure reactlog is disabled for 173

### DIFF
--- a/173-invalidatelater-leak/app.R
+++ b/173-invalidatelater-leak/app.R
@@ -1,6 +1,12 @@
 library(shiny)
 library(pryr)
 
+# It's possible for this test to fail when reactlog is enabled
+op <- options(shiny.reactlog = FALSE)
+onStop(function() {
+  options(op)
+})
+
 ui <- fluidPage(
   p("This application tests if", code("invalidateLater"),
     "causes significant memory leakage. (",


### PR DESCRIPTION
This test app was failing on r-devel windows when `options(shiny.reactlog = TRUE)`. The test no longer fails when reactlog is disabled.