### PR TITLE
Make Superzip shinyloadtest-compatible

### DIFF
--- a/063-superzip-example/server.R
+++ b/063-superzip-example/server.R
@@ -176,7 +176,7 @@ function(input, output, session) {
         is.null(input$zipcodes) | Zipcode %in% input$zipcodes
       ) %>%
       mutate(Action = paste('<a class="go-map" href="" data-lat="', Lat, '" data-long="', Long, '" data-zip="', Zipcode, '"><i class="fa fa-crosshairs"></i></a>', sep=""))
-    action <- DT::dataTableAjax(session, df)
+    action <- DT::dataTableAjax(session, df, outputId = "ziptable")
 
     DT::datatable(df, options = list(ajax = list(url = action)), escape = FALSE)
   })


### PR DESCRIPTION
063-superzip-example wasn't compatible with [shinyloadtest]() because of [this line of code in DT](https://github.com/rstudio/DT/blob/959ccd4e66f281386103e7598a8f7f13ac1fcae0/R/shiny.R#L461).

DT would provide a random default outputId, which would make recordings nondeterministic, as this random ID would be embedded in the shinyloadtest recording.

This fix supplies `DT::dataTableAjax()` an `outputId` parameter which prevents a random one from being generated. Consequently, recordings of the app can now be played back successfully.

~~I have a separate PR for DT in the works.~~
Merged DT PR: https://github.com/rstudio/DT/pull/730