### PR TITLE
Replace dead icon source with original octicons from github

### DIFF
--- a/013-selectize/ui.R
+++ b/013-selectize/ui.R
@@ -54,7 +54,7 @@ fluidPage(
         render = I("{
       option: function(item, escape) {
         return '<div>' +
-               '<strong><img src=\"http://selectize.github.io/selectize.js/images/repo-' + (item.fork ? 'forked' : 'source') + '.png\" width=20 />' + escape(item.name) + '</strong>:' +
+               '<strong><img src=\"https://raw.githubusercontent.com/primer/octicons/refs/heads/main/icons/' + (item.fork ? 'repo-forked' : 'repo') + '-16.svg\" height=14 style=\"padding-right: 3px;\" />' + escape(item.name) + '</strong>:' +
                ' <em>' + escape(item.description) + '</em>' +
                ' (by ' + escape(item.username) + ')' +
             '<ul>' +


### PR DESCRIPTION
Google reverse image search suggests that [Octicons](https://github.com/primer/octicons) were likely the original source of these now-dead images (I dug em up via [the Wayback machine](https://web.archive.org/web/20210706190434/https://selectize.dev/images/repo-source.png)). Looks like they're licensed under the MIT license, which this repo already has a copy of, so should be fine to use them straight from the source.

Also made them match the font height and put a bit of right-padding to make it look better.