### PR TITLE
fix(182-google-charts): use https

### DIFF
--- a/182-google-charts/app.R
+++ b/182-google-charts/app.R
@@ -6,7 +6,8 @@ library(googleCharts)
 library(shiny)
 library(dplyr)
 
-data <- readRDS("healthexp.Rds")
+# data <- readRDS("healthexp.Rds")
+data <- readRDS(url("https://github.com/rstudio/shiny-examples/raw/refs/heads/main/182-google-charts/healthexp.Rds"))
 data$Region <- as.factor(data$Region)
 
 # Use global max/min for axes so the view window stays
@@ -26,7 +27,7 @@ ui <- fluidPage(
 
   # Use the Google webfont "Source Sans Pro"
   tags$link(
-    href=paste0("http://fonts.googleapis.com/css?",
+    href=paste0("https://fonts.googleapis.com/css?",
                 "family=Source+Sans+Pro:300,600,300italic"),
     rel="stylesheet", type="text/css"),
   tags$style(type="text/css",


### PR DESCRIPTION
This pull request updates the `182-google-charts/app.R` file to improve data accessibility and enhance security by switching to HTTPS for external resources. The most important changes include modifying the data source and updating the URL for the Google web font.

### Data Accessibility:
* Changed the data source from a local file (`healthexp.Rds`) to a remote file hosted on GitHub for easier access and version control.

### Security Enhancements:
* Updated the Google web font URL to use `HTTPS` instead of `HTTP`, ensuring secure loading of external resources.